### PR TITLE
Update assert.h: delete __FILE__ macro

### DIFF
--- a/tcvm.cdt/include/libc/assert.h
+++ b/tcvm.cdt/include/libc/assert.h
@@ -5,7 +5,7 @@
 #ifdef NDEBUG
 #define	assert(x) (void)0
 #else
-#define assert(x) ((void)((x) || (__assert_fail(#x, __FILE__, __LINE__, __func__),0)))
+#define assert(x) ((void)((x) || (__assert_fail(#x, "wasm", __LINE__, __func__),0)))
 #endif
 
 #if __STDC_VERSION__ >= 201112L && !defined(__cplusplus)


### PR DESCRIPTION
Inconsistent bytecodes compiled in different environments